### PR TITLE
Increased required memory for Kubernetes pods

### DIFF
--- a/docker/ethz/cloud/kustomize/deployment-guiservice.yml
+++ b/docker/ethz/cloud/kustomize/deployment-guiservice.yml
@@ -51,7 +51,7 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              memory: "600Mi"
+              memory: "1200Mi"
             limits:
               memory: "3Gi"
           ports:

--- a/docker/ethz/cloud/kustomize/deployment-webservice.yml
+++ b/docker/ethz/cloud/kustomize/deployment-webservice.yml
@@ -51,7 +51,7 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              memory: "600Mi"
+              memory: "1200Mi"
             limits:
               memory: "3Gi"
           ports:


### PR DESCRIPTION
Each container uses ~1 GB memory. Current value is set to 600MB, which would allow to spawn a container on a node without sufficient memory. Maximum memory limit remains unaffected (3GB)