### PR TITLE
Set default external access for webservice to https

### DIFF
--- a/docker/ethz/cloud/kustomize/deployment-guiservice.yml
+++ b/docker/ethz/cloud/kustomize/deployment-guiservice.yml
@@ -84,11 +84,11 @@ spec:
               
 # NOTE: Set the below URL component settings from where the gui-service is externally available
             - name: "sebserver_gui_http_external_scheme"
-              value: "http"
+              value: "https"
             - name: "sebserver_gui_http_external_servername"
               value: "seb-guiservice-prod"
             - name: "sebserver_gui_http_external_port"
-              value: ""
+              value: "443"
 # NOTE: Set the below URL component settings from where the gui-service can connect to the web-service
             - name: "sebserver_gui_http_webservice_scheme"
               value: "http"


### PR DESCRIPTION
Corresponds to configuration of webservice: external access uses https by default