### PR TITLE
Update broken setup image on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,10 +44,9 @@ The image below shows a very simplified diagram that locates the SEB Server in a
 Safe Exam Browser (SEB). The SEB Server communicates with the LMS for managing and prepare exams as well as with the SEB Client to ensure 
 a more automated and secure setup for high-stake exams.
 
-.. image:: https://raw.githubusercontent.com/SafeExamBrowser/seb-server/rel-2.0/docs/images/setup_1.png
+.. image:: https://raw.githubusercontent.com/SafeExamBrowser/seb-server/refs/heads/master/docs/images/setup_1.png
     :align: center
-    :target: https://raw.githubusercontent.com/SafeExamBrowser/seb-server/rel-2.0/docs/images/setup_1.png
-
+    :target: https://raw.githubusercontent.com/SafeExamBrowser/seb-server/refs/heads/master/docs/images/setup_1.png
 
 Install SEB Server
 ------------------


### PR DESCRIPTION
I noticed the link to the image on the README was broken and no longer pointing to 

![](https://raw.githubusercontent.com/SafeExamBrowser/seb-server/refs/heads/master/docs/images/setup_1.png)