### PR TITLE
Added readiness probe to seb webservice

### DIFF
--- a/docker/ethz/cloud/kustomize/deployment-webservice.yml
+++ b/docker/ethz/cloud/kustomize/deployment-webservice.yml
@@ -64,6 +64,18 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 5
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /sebserver/check
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 1
+            successThreshold: 1
           volumeMounts:
             - name: application-properties
               mountPath: /sebserver/config/spring


### PR DESCRIPTION
Readiness probe tests if pod responds, as liveness probe does already. 

A failed Liveness probe will stop a pod, and Kubernetes restarts it. Readiness probe will not stop a pod, but prohibit any new requests to this probe. 

The readiness probe triggers first. This will allow longer lasting requests to hopefully terminate correctly. After 5 failures or 25 seconds, the pod is considered dead and will be restarted. Currently, a pod gets restarted after 5 seconds by the liveness probe.
